### PR TITLE
Improve wording for Level Zero restrictors

### DIFF
--- a/mem_alloc.tex
+++ b/mem_alloc.tex
@@ -130,19 +130,11 @@ Level Zero runtime system~\cite{zeref}.
 
 \begin{itemize}
 
-\item \infokey{host}: Support for memory allocated on the host that is
-    accessible by Level Zero devices (\eg, memory allocations from the
-        \function{zeMemAllocHost()} function).
-        These memory allocations are attributed with \function{ZE\_MEMORY\_TYPE\_HOST}.
+\item \infokey{host}: Support for memory that is owned by the host and is accessible by the host and by any Level Zero devices
 
-\item \infokey{device}: Support for memory allocated on a Level Zero device
-    (\eg, memory allocations from the \function{zeMemAllocDevice()} function).
-        These memory allocations are attributed with \function{ZE\_MEMORY\_TYPE\_DEVICE}.
+\item \infokey{device}: Support for memory that is owned by a specific Level Zero device
 
-\item \infokey{shared}: Support for memory allocated that will be shared
-    between the host and one or more Level Zero devices (\eg,
-        memory allocations from the \function{zeMemAllocShared()} function).
-        These memory allocations are attributed with \function{ZE\_MEMORY\_TYPE\_SHARED}.
+\item \infokey{shared}: Support for memory that has shared ownership between the host and one or more Level Zero devices
 
 \end{itemize}
 


### PR DESCRIPTION
Intel would like to modify the wording for the Level Zero restrictors to remove direct references to Level Zero APIs and align the significant properties with the intended semantic differences between these kinds of memory allocation.