### PR TITLE
Add statement to describe applicability to higher-level programming models

### DIFF
--- a/mem_alloc.tex
+++ b/mem_alloc.tex
@@ -70,7 +70,7 @@ also explains their usage model.
 This chapter contains definitions of memory allocation kinds and
 their restrictors for different memory types.
 
-Although the currently defined memory kinds map to low-level
+Although the currently defined memory allocation kinds map to low-level
 GPU programming models, they can also be used with higher-level
 programming models like SYCL (as shown in
 \exref{example:alloc-kind-spm-sycl}) or OpenMP if their underlying

--- a/mem_alloc.tex
+++ b/mem_alloc.tex
@@ -71,10 +71,10 @@ This chapter contains definitions of memory allocation kinds and
 their restrictors for different memory types.
 
 Although the currently defined memory allocation kinds map to low-level
-GPU programming models, they can also be used with higher-level
-programming models like SYCL (as shown in
-\exref{example:alloc-kind-spm-sycl}) or OpenMP if their underlying
-implementation uses the corresponding memory allocator.
+GPU programming models, they can also be used in programs that use
+higher-level abstractions like SYCL (as shown in
+\exref{example:alloc-kind-spm-sycl}) or the OpenMP API if their
+underlying implementations use the corresponding memory allocator.
 
 \section{CUDA memory kind}
 

--- a/mem_alloc.tex
+++ b/mem_alloc.tex
@@ -70,6 +70,12 @@ also explains their usage model.
 This chapter contains definitions of memory allocation kinds and
 their restrictors for different memory types.
 
+Although the currently defined memory kinds map to low-level
+GPU programming models, they can also be used with higher-level
+programming models like SYCL (as shown in
+\exref{example:alloc-kind-spm-sycl}) or OpenMP if their underlying
+implementation uses the corresponding memory allocator.
+
 \section{CUDA memory kind}
 
 We define \infokey{cuda} as a memory kind that refers to the memory


### PR DESCRIPTION
Given the lack of an example with OpenMP in the current version of the document, one of the concerns brought forth was that the memory kinds idea may not apply to OpenMP GPU applications. 

This statement is an attempt to address that concern.

@mjklemm 