### PR TITLE
remove printf statements

### DIFF
--- a/examples-src/Side-doc-HIP-example.c
+++ b/examples-src/Side-doc-HIP-example.c
@@ -65,11 +65,9 @@ int main(int argc, char *argv[])
     
     if (rocm_device_aware) {
         MPI_File_read(file, device_buf, BUFSIZE, MPI_INT, &status);
-	printf("Using if part\n");
     }
     else {
         int *tmp_buf;
-	printf("Using else part\n");
 	tmp_buf = (int*) malloc (BUFSIZE * sizeof(int));
 	MPI_File_read(file, tmp_buf, BUFSIZE, MPI_INT, &status);
 

--- a/mem_alloc.tex
+++ b/mem_alloc.tex
@@ -804,11 +804,9 @@ int main(int argc, char *argv[])
 
     if (rocm_device_aware) {
         MPI_File_read(file, device_buf, BUFSIZE, MPI_INT, &status);
-        printf("Using if part\n");
     }
     else {
         int *tmp_buf;
-        printf("Using else part\n");
         tmp_buf = (int*) malloc (BUFSIZE * sizeof(int));
         MPI_File_read(file, tmp_buf, BUFSIZE, MPI_INT, &status);
 


### PR DESCRIPTION
somehow some printf statements have creeped into the hip/rocm examples. I am honestly not sure how we didn't notice that before.