### PR TITLE
update rocm example

### DIFF
--- a/mem_alloc.tex
+++ b/mem_alloc.tex
@@ -770,7 +770,9 @@ int main(int argc, char *argv[])
 
     // Usage mode: REQUESTED
     // Supply mpi_memory_alloc_kinds to the MPI startup
-    // mechanism (not shown)
+    // mechanism, e.g.
+    //    mpiexec -memory-alloc-kinds system,mpi,rocm:device ...
+    // See section 11.5 in MPI 4.1 for more details
     MPI_Init(&argc, &argv);
 
     // Usage mode: PROVIDED

--- a/mem_alloc.tex
+++ b/mem_alloc.tex
@@ -771,7 +771,7 @@ int main(int argc, char *argv[])
     // Usage mode: REQUESTED
     // Supply mpi_memory_alloc_kinds to the MPI startup
     // mechanism, e.g.
-    //    mpiexec -memory-alloc-kinds system,mpi,rocm:device ...
+    //    mpiexec -memory-alloc-kinds system,mpi,rocm:device -n 10 ./my_app
     // See section 11.5 in MPI 4.1 for more details
     MPI_Init(&argc, &argv);
 


### PR DESCRIPTION
based on the feedback of the reading at the MPI Forum in March 2024 in Chicago, update the rocm example to include the syntax on how to pass the memory allocation kinds to the mpiexec command.